### PR TITLE
10 raglocalchunking extending chunk schema  to propagate document metadata into chunks

### DIFF
--- a/rag_local/chunking.py
+++ b/rag_local/chunking.py
@@ -13,26 +13,50 @@ Optional:
     Start character index within the original text (inclusive).
 - end: int
     End character index within the original text (exclusive).
+- doc_id: str
+    Identifier of the parent document (propagated from input).
+- source: str
+    Source of the parent document (e.g., filename, URL).
+- metadata: dict
+    Optional metadata propagated from the parent document.
 
 Example chunk object
 --------------------
 chunk = {
-    "chunk_id": "a1b2c3d4e5f6g7h8",
+    "chunk_id": "doc123::chunk_0",
     "text": "This is the chunk text ...",
     "start": 0,
-    "end": 500
+    "end": 500,
+    "doc_id": "doc123",
+    "source": "example.pdf",
+    "metadata": {
+        "author": "Jane Doe",
+        "category": "lecture_notes"
+    }
 }
 
 Public API
 ----------
-- chunk_text(text: str, *, chunk_size: int = 800, overlap: int = 200,
-            doc_id: str | None = None, include_spans: bool = True) -> list[Chunk]
+- chunk_text(
+      text: str,
+      *,
+      chunk_size: int = 800,
+      overlap: int = 200,
+      doc_id: str | None = None,
+      source: str | None = None,
+      metadata: dict | None = None,
+      include_spans: bool = True
+  ) -> list[Chunk]
 
 Notes
 -----
 - No NLP libraries required (pure Python).
-- This implementation chunks by character count (baseline).
+- Baseline implementation uses fixed-size, character-based chunking.
 - You can later add token-based chunking, sentence boundaries, etc., while keeping the schema stable.
+- Chunk order is deterministic across runs when inputs are unchanged.
+- If doc_id is not provided, a deterministic hash-based chunk_id is used.
+- The output schema is designed to remain stable as future enhancements
+  (token-based chunking, sentence boundaries, etc.) are added.
 """
 
 from __future__ import annotations
@@ -40,11 +64,9 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, TypedDict
 import hashlib
 
-
 # -----------------------------
 # Chunk schema (contract)
 # -----------------------------
-
 class Chunk(TypedDict, total=False):
     """
     Standard chunk schema for chunking output.
@@ -67,7 +89,6 @@ class Chunk(TypedDict, total=False):
     doc_id: str
     source: str
     metadata: Dict[str, Any]
-
 
 # -----------------------------
 # Public entrypoint
@@ -189,7 +210,6 @@ def _make_chunk(
     """
     Normalize chunk output into the Chunk schema and generate a stable chunk_id.
     """
-    # chunk_id = make_chunk_id(doc_id=doc_id, start=start, end=end, chunk_text=chunk_text)
     chunk_id = make_chunk_id(doc_id=doc_id,index=index,start=start,end=end,chunk_text=chunk_text)
     chunk: Chunk = {
         "chunk_id": chunk_id,
@@ -207,8 +227,6 @@ def _make_chunk(
         chunk["metadata"] = dict(metadata) # shallow copy to avoid accidental mutation across chunks
     return chunk
 
-
-# def make_chunk_id(*, doc_id: Optional[str], start: int, end: int, chunk_text: str) -> str:
 def make_chunk_id(*, doc_id: Optional[str], index: int, start: int, end: int, chunk_text: str) -> str:
     """
     Create a deterministic chunk identifier.

--- a/rag_local/chunking.py
+++ b/rag_local/chunking.py
@@ -36,9 +36,8 @@ Notes
 """
 
 from __future__ import annotations
-
 from dataclasses import dataclass
-from typing import List, Optional, TypedDict
+from typing import Any, Dict, List, Optional, TypedDict
 import hashlib
 
 
@@ -57,11 +56,17 @@ class Chunk(TypedDict, total=False):
     Optional keys:
       - start: start char index in original text (inclusive)
       - end: end char index in original text (exclusive)
+      - doc_id: document identifier (propagated from parent)
+      - source: document source (propagated from parent)
+      - metadata: optional metadata from parent document
     """
     chunk_id: str
     text: str
     start: int
     end: int
+    doc_id: str
+    source: str
+    metadata: Dict[str, Any]
 
 
 # -----------------------------
@@ -74,6 +79,8 @@ def chunk_text(
     chunk_size: int = 800,
     overlap: int = 200,
     doc_id: Optional[str] = None,
+    source: Optional[str] = None,
+    metadata: Optional[Dict[str, Any]] = None,
     include_spans: bool = True,
 ) -> List[Chunk]:
     """
@@ -98,6 +105,13 @@ def chunk_text(
     doc_id:
         Optional document identifier used to make chunk_id stable across runs
         and unique across documents.
+
+    source:
+        Optional document source string (e.g., filename, URL, dataset key).
+        If provided, it will be propagated into each chunk.
+    metadata:
+        Optional metadata dictionary from the parent document. If provided,
+        it will be propagated into each chunk (shallow-copied).
     include_spans:
         If True, include start/end indices in each chunk.
 
@@ -122,7 +136,7 @@ def chunk_text(
     # Deterministic traversal
     start = 0
     n = len(text)
-
+    i = 0
     while start < n:
         end = min(start + chunk_size, n)
         chunk_str = text[start:end]
@@ -134,6 +148,9 @@ def chunk_text(
             start=start,
             end=end,
             doc_id=doc_id,
+            source=source,
+            metadata=metadata,
+            index=i
             include_spans=include_spans,
         )
         chunks.append(chunk)
@@ -141,7 +158,7 @@ def chunk_text(
         if end == n:
             break
         start += step
-
+        i += 1
     return chunks
 
 
@@ -164,12 +181,16 @@ def _make_chunk(
     start: int,
     end: int,
     doc_id: Optional[str],
+    source: Optional[str],
+    metadata: Optional[Dict[str, Any]],
+    index: int,
     include_spans: bool,
 ) -> Chunk:
     """
     Normalize chunk output into the Chunk schema and generate a stable chunk_id.
     """
-    chunk_id = make_chunk_id(doc_id=doc_id, start=start, end=end, chunk_text=chunk_text)
+    # chunk_id = make_chunk_id(doc_id=doc_id, start=start, end=end, chunk_text=chunk_text)
+    chunk_id = make_chunk_id(doc_id=doc_id,index=index,start=start,end=end,chunk_text=chunk_text)
     chunk: Chunk = {
         "chunk_id": chunk_id,
         "text": chunk_text,
@@ -177,20 +198,31 @@ def _make_chunk(
     if include_spans:
         chunk["start"] = start
         chunk["end"] = end
+    # Propagate document context (if provided)
+    if doc_id is not None:
+        chunk["doc_id"] = doc_id
+    if source is not None:
+        chunk["source"] = source
+    if metadata is not None:
+        chunk["metadata"] = dict(metadata) # shallow copy to avoid accidental mutation across chunks
     return chunk
 
 
-def make_chunk_id(*, doc_id: Optional[str], start: int, end: int, chunk_text: str) -> str:
+# def make_chunk_id(*, doc_id: Optional[str], start: int, end: int, chunk_text: str) -> str:
+def make_chunk_id(*, doc_id: Optional[str], index: int, start: int, end: int, chunk_text: str) -> str:
     """
     Create a deterministic chunk identifier.
-
     Strategy:
-    - Hash(doc_id + start/end + chunk_text)
-    - If doc_id is None, the id is still deterministic for the same text content,
-      but doc_id is strongly recommended to avoid collisions across documents.
+    - If doc_id is None: 
+        Fall back to a deterministic Hash(doc_id + start/end + chunk_text). The id is still deterministic for the same text content
+        but doc_id is recommended to avoid collisions across documents.
+    - If doc_id is provided: 
+        Use globally unique readable ID: "{doc_id}::chunk_{i}" (Deterministic given stable doc_id and chunking params.) 
     """
+    if doc_id:
+        return f"{doc_id}::chunk_{index}"
     h = hashlib.sha256()
-    h.update((doc_id or "NO_DOC_ID").encode("utf-8"))
+    h.update("NO_DOC_ID".encode("utf-8"))
     h.update(b"\n")
     h.update(f"{start}:{end}".encode("utf-8"))
     h.update(b"\n")


### PR DESCRIPTION

1) Extend the Chunk schema to include fields:
- doc_id: str
- source: str
- metadata: dict (optional)

2) Extend chunk_text(...) signature
Add optional parameters:
- source: Optional[str] = None
- metadata: Optional[dict] = None

3) Generate IDs as {doc_id}::chunk_{i}
Uses a simple i counter in the while loop.
- If doc_id is missing, fall back to your current hash-based ID (so old use-cases should still work).