### PR TITLE
12 rag locallocal indexpy implement embedding generation for chunks and queries

### DIFF
--- a/rag_local/local_index.py
+++ b/rag_local/local_index.py
@@ -4,7 +4,6 @@ rag_local.local_index
 Goal
 ----
 Define a minimal *local vector index* interface that supports:
-
 - add(chunks)
 - search(query, top_k)
 - save(path)
@@ -64,29 +63,32 @@ from typing import Any, Dict, List, Optional, Protocol, Sequence, Tuple, TypedDi
 import json
 import math
 
-
 # -----------------------------
 # Types / Contracts
 # -----------------------------
-
 class Chunk(TypedDict, total=False):
     """
-    Minimal chunk contract expected by the index.
-
-    Required:
-      - chunk_id: str
-      - text: str
-
-    Optional:
-      - start: int
-      - end: int
-      - (you may add meta later upstream, but keep required keys stable)
+    Standard chunk schema for chunking output.
+    Required keys:
+      - chunk_id: stable identifier string
+      - text: chunk text
+    Optional keys:
+      - start: start char index in original text (inclusive)
+      - end: end char index in original text (exclusive)
+      - doc_id: document identifier (propagated from parent)
+      - source: document source (propagated from parent)
+      - metadata: optional metadata from parent document
+      - embedding: list[float]   # <-- important (stored with chunk metadata)
     """
     chunk_id: str
     text: str
+  
     start: int
     end: int
-
+    doc_id: str
+    source: str
+    metadata: Dict[str, Any]
+    embedding: List[float]
 
 class SearchResult(TypedDict, total=False):
     """
@@ -98,12 +100,14 @@ class SearchResult(TypedDict, total=False):
     # Optional fields (carried through if present)
     start: int
     end: int
-
+    doc_id: str
+    source: str
+    metadata: Dict[str, Any]
+    embedding: List[float]
 
 class Embedder(Protocol):
     """
     Embedder interface so indexing doesn't care where embeddings come from.
-
     Implementations might use:
     - sentence-transformers
     - ollama embeddings endpoint
@@ -111,42 +115,61 @@ class Embedder(Protocol):
     """
     def embed_texts(self, texts: Sequence[str]) -> List[List[float]]:
         ...
-
     def embed_query(self, query: str) -> List[float]:
         ...
+
+class SentenceTransformerEmbedder:
+    """
+    SentenceTransformers-based embedder.
+    Requirements satisfied:
+    - Same embedding method for chunks and queries.
+    - Deterministic given same model + same inputs.
+    - Returns JSON-serializable List[List[float]] and List[float].
+    """
+    def __init__(self, model_name: str = "all-MiniLM-L6-v2", *, normalize: bool = True) -> None:
+        try:
+            from sentence_transformers import SentenceTransformer  # type: ignore
+        except ImportError as e:
+            raise ImportError(
+              "sentence-transformers is not installed. Install with: pip install sentence-transformers"
+            ) from e
+        self.model_name = model_name
+        self.normalize = normalize
+        self._model = SentenceTransformer(model_name)
+
+    def embed_texts(self, texts: Sequence[str]) -> List[List[float]]:
+        vecs = self._model.encode(list(texts), normalize_embeddings=self.normalize,convert_to_numpy=True,show_progress_bar=False)
+        return vecs.tolist()
+
+    def embed_query(self, query: str) -> List[float]:
+        vec = self._model.encode(query,normalize_embeddings=self.normalize, convert_to_numpy=True,show_progress_bar=False)
+        return vec.tolist()
 
 
 # -----------------------------
 # Public Index Interface
 # -----------------------------
-
 class LocalVectorIndex(Protocol):
     """
     Minimal index interface required by the project.
     """
     def add(self, chunks: Sequence[Chunk]) -> None:
         ...
-
     def search(self, query: str, top_k: int = 5) -> List[SearchResult]:
         ...
-
     def save(self, path: Union[str, Path]) -> None:
         ...
-
     @classmethod
     def load(cls, path: Union[str, Path], *, embedder: Embedder) -> "LocalVectorIndex":
         ...
 
-
 # -----------------------------
 # Baseline Implementation
 # -----------------------------
-
 @dataclass
 class SimpleLocalIndex:
     """
     A simple in-memory vector index with JSON persistence.
-
     Notes:
     - Intended as a baseline implementation.
     - Linear search (O(n)) is fine for class-scale datasets.
@@ -164,7 +187,6 @@ class SimpleLocalIndex:
     def add(self, chunks: Sequence[Chunk]) -> None:
         """
         Add chunks to the index.
-
         Contract:
         - One vector per chunk
         - chunks are appended in order provided (deterministic)
@@ -178,13 +200,16 @@ class SimpleLocalIndex:
         if len(vecs) != len(chunks):
             raise ValueError("Embedder returned mismatched number of vectors.")
 
+        # Store embedding with metadata
+        for c, v in zip(chunks, vecs):
+            c["embedding"] = v  
+
         self.chunks.extend(list(chunks))
         self.vectors.extend(vecs)
 
     def search(self, query: str, top_k: int = 5) -> List[SearchResult]:
         """
         Search the index using cosine similarity.
-
         Returns:
         - top_k SearchResult objects with score in descending order
         """
@@ -192,7 +217,8 @@ class SimpleLocalIndex:
             raise ValueError("top_k must be > 0")
         if not self.chunks:
             return []
-
+          
+        # Same embedder used for both chunks and queries
         qvec = self.embedder.embed_query(query)
         scored: List[Tuple[int, float]] = []
 
@@ -215,6 +241,12 @@ class SimpleLocalIndex:
                 r["start"] = int(c["start"])
             if "end" in c:
                 r["end"] = int(c["end"])
+            if "doc_id" in c:
+                r["doc_id"] = c["doc_id"]
+            if "source" in c:
+                r["source"] = c["source"]
+            if "metadata" in c:
+                r["metadata"] = c["metadata"]
             results.append(r)
 
         return results
@@ -222,7 +254,6 @@ class SimpleLocalIndex:
     def save(self, path: Union[str, Path]) -> None:
         """
         Save index contents to disk as JSON.
-
         Stored:
         - chunks
         - vectors
@@ -233,6 +264,12 @@ class SimpleLocalIndex:
             "version": 1,
             "chunks": self.chunks,
             "vectors": self.vectors,
+            "embedder": {  # Addition to payload to include embedder if we want to document the embedding method used
+              "type": self.embedder.__class__.__name__,
+              "model_name": getattr(self.embedder, "model_name", None),
+              "normalize": getattr(self.embedder, "normalize", None),
+              "vector_dim": (len(self.vectors[0]) if self.vectors else None),
+            },
         }
         p.parent.mkdir(parents=True, exist_ok=True)
         p.write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
@@ -245,32 +282,36 @@ class SimpleLocalIndex:
         p = Path(path).expanduser().resolve()
         if not p.exists():
             raise FileNotFoundError(f"Index file not found: {p}")
-
         payload = json.loads(p.read_text(encoding="utf-8"))
-
         idx = cls(embedder=embedder)
         idx.chunks = payload.get("chunks", [])
         idx.vectors = payload.get("vectors", [])
 
+        # If vectors are missing, rebuild them from per-chunk embeddings:
+        if not idx.vectors and idx.chunks:
+            rebuilt: List[List[float]] = []
+            for c in idx.chunks:
+                emb = c.get("embedding")
+                if emb is None:
+                      raise ValueError("Index missing vectors and chunk embeddings; cannot rebuild.")
+                rebuilt.append(list(emb))
+            idx.vectors = rebuilt
+          
+        # Verify they match in length
         if len(idx.chunks) != len(idx.vectors):
             raise ValueError("Corrupt index: chunks and vectors length mismatch.")
-
         return idx
-
 
 # -----------------------------
 # Similarity (baseline)
 # -----------------------------
-
 def cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
     """
     Compute cosine similarity between two vectors.
-
     Returns a float in [-1, 1] (typical embedding spaces yield ~[0, 1]).
     """
     if len(a) != len(b):
         raise ValueError("Vector dimension mismatch.")
-
     dot = 0.0
     na = 0.0
     nb = 0.0
@@ -278,10 +319,8 @@ def cosine_similarity(a: Sequence[float], b: Sequence[float]) -> float:
         dot += x * y
         na += x * x
         nb += y * y
-
     if na == 0.0 or nb == 0.0:
         return 0.0
     return dot / (math.sqrt(na) * math.sqrt(nb))
-
 
 

--- a/rag_local/rag.py
+++ b/rag_local/rag.py
@@ -49,7 +49,7 @@ def build_index(
             overlap=overlap,
             doc_id=doc_id,
             source=source,
-            metadata=d.get("meta", None),
+            metadata=d.get("metadata", d.get("meta", None)),
             include_spans=True,
         )
         all_chunks.extend(chunks)


### PR DESCRIPTION
Updated local_index.py to implement embeddings for chunk texts and queries using recommended SentenceTransformers. Fulfills requirements to use same embedding method for chunks and queries and storing embeddings with chunk metadata. 

Updated rag.py to standardize document metadata key