### PR TITLE
Bugfixes gui

### DIFF
--- a/rag_local/paper_rerank.py
+++ b/rag_local/paper_rerank.py
@@ -80,6 +80,47 @@ def _clamp01(x: float) -> float:
     return max(0.0, min(1.0, float(x)))
 
 
+def _extract_score_from_text(text: str) -> Optional[float]:
+    """
+    Parse a numeric relevance score from free-form model output.
+
+    Handles cases where the model returns additional explanation despite
+    instructions to output only a number.
+    """
+    s = (text or "").strip()
+    if not s:
+        return None
+
+    # Fast path for clean numeric output.
+    try:
+        return _clamp01(float(s))
+    except Exception:
+        pass
+
+    # Fallback: capture numeric substrings (e.g., "0.2\n\nExplanation...").
+    matches = re.findall(r"[-+]?\d*\.?\d+", s)
+    if not matches:
+        return None
+
+    # Prefer a value already in [0,1] if present.
+    for m in matches:
+        try:
+            val = float(m)
+            if 0.0 <= val <= 1.0:
+                return val
+        except Exception:
+            continue
+
+    # Otherwise clamp the first parseable number.
+    for m in matches:
+        try:
+            return _clamp01(float(m))
+        except Exception:
+            continue
+
+    return None
+
+
 # --------------------------------------------------------
 # Text helpers
 # --------------------------------------------------------
@@ -299,9 +340,12 @@ Return ONLY a number between 0.0 and 1.0.
             return 0.0, f"LLM reranker unavailable ({r.status_code}); continuing without it."
         data = r.json()
         text = str(data.get("response", "")).strip()
-        return _clamp01(float(text)), None
+        parsed = _extract_score_from_text(text)
+        if parsed is None:
+            return 0.0, "LLM reranker unavailable (non-numeric model output); continuing without it."
+        return parsed, None
     except Exception as e:
-        return 0.0, f"LLM reranker unavailable ({e}); continuing without it."
+        return 0.0, f"LLM reranker unavailable ({type(e).__name__}); continuing without it."
 
 
 # --------------------------------------------------------

--- a/rag_local/paper_rerank.py
+++ b/rag_local/paper_rerank.py
@@ -97,6 +97,17 @@ def _extract_score_from_text(text: str) -> Optional[float]:
     except Exception:
         pass
 
+    # Handle fraction-style ratings first (e.g., "7/10" -> 0.7).
+    frac = re.search(r"(?<!\d)(\d+(?:\.\d+)?)\s*/\s*(\d+(?:\.\d+)?)(?!\d)", s)
+    if frac:
+        try:
+            num = float(frac.group(1))
+            den = float(frac.group(2))
+            if den != 0:
+                return _clamp01(num / den)
+        except Exception:
+            pass
+
     # Fallback: capture numeric substrings (e.g., "0.2\n\nExplanation...").
     matches = re.findall(r"[-+]?\d*\.?\d+", s)
     if not matches:

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -638,7 +638,9 @@ if st.session_state.get("search_result_summary"):
 
 ranked_results = st.session_state.get("search_results", [])
 if ranked_results and st.session_state.get("show_search_results", False):
-    with st.sidebar.expander("Candidate sources", expanded=False):
+    # Keep this open by default so checkbox interactions don't feel like the
+    # list "disappeared" on rerun.
+    with st.sidebar.expander("Candidate sources", expanded=True):
         for r in ranked_results:
             key = f"pick_{r.source}_{r.id}"
             year_part = f" ({r.year})" if r.year else ""

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -390,136 +390,135 @@ if run_eval_btn:
 st.sidebar.markdown("---")
 st.sidebar.subheader("Search")
 
-with st.sidebar.form("search_form", clear_on_submit=False):
-    search_mode = st.selectbox(
-        "Search Mode",
-        options=["Academic (OpenAlex)", "General Knowledge (Wikipedia)", "Hybrid"],
-        index=["Academic (OpenAlex)", "General Knowledge (Wikipedia)", "Hybrid"].index(
-            st.session_state.get("last_search_mode", "Academic (OpenAlex)")
-        ),
-        key="search_mode",
-    )
-    st.session_state.last_search_mode = search_mode
+search_mode = st.sidebar.selectbox(
+    "Search Mode",
+    options=["Academic (OpenAlex)", "General Knowledge (Wikipedia)", "Hybrid"],
+    index=["Academic (OpenAlex)", "General Knowledge (Wikipedia)", "Hybrid"].index(
+        st.session_state.get("last_search_mode", "Academic (OpenAlex)")
+    ),
+    key="search_mode",
+)
+st.session_state.last_search_mode = search_mode
 
-    search_query = st.text_input(
-        "Search query",
-        key="search_query",
-        value=st.session_state.get("search_query", ""),
-    )
+search_query = st.sidebar.text_input(
+    "Search query",
+    key="search_query",
+    value=st.session_state.get("search_query", ""),
+)
 
-    search_topic = st.text_input(
-        "Research topic",
-        key="search_topic",
-        value=st.session_state.get("search_topic", ""),
-    )
+search_topic = st.sidebar.text_input(
+    "Research topic",
+    key="search_topic",
+    value=st.session_state.get("search_topic", ""),
+)
 
-    search_research_question = st.text_area(
-        "Research question",
-        key="search_research_question",
-        value=st.session_state.get("search_research_question", ""),
-        height=90,
-        help="What exactly are you trying to learn, compare, explain, or solve?",
-    )
+search_research_question = st.sidebar.text_area(
+    "Research question",
+    key="search_research_question",
+    value=st.session_state.get("search_research_question", ""),
+    height=90,
+    help="What exactly are you trying to learn, compare, explain, or solve?",
+)
 
-    search_level = st.selectbox(
-        "Education / familiarity level",
-        options=["high_school", "undergraduate", "masters", "phd"],
-        index=1,
-        key="search_level",
-    )
+search_level = st.sidebar.selectbox(
+    "Education / familiarity level",
+    options=["high_school", "undergraduate", "masters", "phd"],
+    index=1,
+    key="search_level",
+)
 
-    oa_mailto = st.text_input(
-        "OpenAlex mailto (recommended)",
-        key="oa_mailto",
-        value=st.session_state.get("oa_mailto", ""),
-    )
+oa_mailto = st.sidebar.text_input(
+    "OpenAlex mailto (recommended)",
+    key="oa_mailto",
+    value=st.session_state.get("oa_mailto", ""),
+)
 
-    if search_mode == "Academic (OpenAlex)":
-        search_limit_default = 50
-    elif search_mode == "General Knowledge (Wikipedia)":
-        search_limit_default = 20
-    else:
-        search_limit_default = 30
+if search_mode == "Academic (OpenAlex)":
+    search_limit_default = 50
+elif search_mode == "General Knowledge (Wikipedia)":
+    search_limit_default = 20
+else:
+    search_limit_default = 30
 
-    search_limit = st.slider(
-        "Initial candidate pool",
-        10, 200, search_limit_default, step=5, key="search_limit"
-    )
+search_limit = st.sidebar.slider(
+    "Initial candidate pool",
+    10, 200, search_limit_default, step=5, key="search_limit"
+)
 
-    strategy_name = st.selectbox(
-        "Search strategy",
-        options=[
-            "Balanced",
-            "Academic Precision",
-            "Broad Overview",
-            "Beginner-Friendly",
-            "Research-Heavy",
-        ],
-        index=0,
-        key="strategy_name",
-        help="Recommended preset for layered reranking. Use Advanced controls only if you want manual tuning.",
-    )
+strategy_name = st.sidebar.selectbox(
+    "Search strategy",
+    options=[
+        "Balanced",
+        "Academic Precision",
+        "Broad Overview",
+        "Beginner-Friendly",
+        "Research-Heavy",
+    ],
+    index=0,
+    key="strategy_name",
+    help="Recommended preset for layered reranking. Use Advanced controls only if you want manual tuning.",
+)
 
-    advanced_override = st.checkbox(
-        "Advanced controls",
-        value=False,
-        key="advanced_override",
-        help="Enable manual reranking controls.",
-    )
+advanced_override = st.sidebar.checkbox(
+    "Advanced controls",
+    value=False,
+    key="advanced_override",
+    help="Enable manual reranking controls.",
+)
 
-    # Manual defaults
-    search_prefilter_k_manual = st.slider(
-        "Lexical prefilter keep",
-        5, 100, 25, step=5, key="search_prefilter_k_manual",
-        disabled=not advanced_override,
-    )
+# Manual defaults
+search_prefilter_k_manual = st.sidebar.slider(
+    "Lexical prefilter keep",
+    5, 100, 25, step=5, key="search_prefilter_k_manual",
+    disabled=not advanced_override,
+)
 
-    search_w_sem_manual = st.slider(
-        "Semantic weight",
-        min_value=0.0, max_value=1.0, value=0.50, step=0.05,
-        key="search_w_sem_manual",
-        disabled=not advanced_override,
-    )
-    search_w_bm25_manual = st.slider(
-        "BM25 weight",
-        min_value=0.0, max_value=1.0, value=0.20, step=0.05,
-        key="search_w_bm25_manual",
-        disabled=not advanced_override,
-    )
-    search_w_lex_manual = st.slider(
-        "Lexical intent weight",
-        min_value=0.0, max_value=1.0, value=0.15, step=0.05,
-        key="search_w_lex_manual",
-        disabled=not advanced_override,
-    )
-    search_w_llm_manual = st.slider(
-        "LLM judge weight",
-        min_value=0.0, max_value=1.0, value=0.10, step=0.05,
-        key="search_w_llm_manual",
-        disabled=not advanced_override,
-    )
-    search_w_audience_manual = st.slider(
-        "Audience-level weight",
-        min_value=0.0, max_value=1.0, value=0.05, step=0.05,
-        key="search_w_audience_manual",
-        disabled=not advanced_override,
-    )
+search_w_sem_manual = st.sidebar.slider(
+    "Semantic weight",
+    min_value=0.0, max_value=1.0, value=0.50, step=0.05,
+    key="search_w_sem_manual",
+    disabled=not advanced_override,
+)
+search_w_bm25_manual = st.sidebar.slider(
+    "BM25 weight",
+    min_value=0.0, max_value=1.0, value=0.20, step=0.05,
+    key="search_w_bm25_manual",
+    disabled=not advanced_override,
+)
+search_w_lex_manual = st.sidebar.slider(
+    "Lexical intent weight",
+    min_value=0.0, max_value=1.0, value=0.15, step=0.05,
+    key="search_w_lex_manual",
+    disabled=not advanced_override,
+)
+search_w_llm_manual = st.sidebar.slider(
+    "LLM judge weight",
+    min_value=0.0, max_value=1.0, value=0.10, step=0.05,
+    key="search_w_llm_manual",
+    disabled=not advanced_override,
+)
+search_w_audience_manual = st.sidebar.slider(
+    "Audience-level weight",
+    min_value=0.0, max_value=1.0, value=0.05, step=0.05,
+    key="search_w_audience_manual",
+    disabled=not advanced_override,
+)
 
-    use_llm_reranker = st.checkbox(
-        "Enable LLM reranker (optional)",
-        value=False,
-        key="search_use_llm_reranker",
-        help="Uses Ollama generation for the last scoring layer. Safe fallback if unavailable.",
-    )
+use_llm_reranker = st.sidebar.checkbox(
+    "Enable LLM reranker (optional)",
+    value=False,
+    key="search_use_llm_reranker",
+    help="Uses Ollama generation for the last scoring layer. Safe fallback if unavailable.",
+)
 
-    search_llm_model = st.text_input(
-        "LLM reranker model",
-        value=st.session_state.get("search_llm_model", "llama3.1:8b"),
-        key="search_llm_model",
-        help="Only used if LLM reranker is enabled.",
-    )
+search_llm_model = st.sidebar.text_input(
+    "LLM reranker model",
+    value=st.session_state.get("search_llm_model", "llama3.1:8b"),
+    key="search_llm_model",
+    help="Only used if LLM reranker is enabled.",
+)
 
-    submitted_search = st.form_submit_button("Search", use_container_width=True)
+submitted_search = st.sidebar.button("Search", key="search_submit_btn", use_container_width=True)
 
 search_w_sem, search_w_bm25, search_w_lex, search_w_llm, search_w_audience, search_prefilter_k = resolve_search_strategy(
     strategy_name,
@@ -971,8 +970,3 @@ if ranked_results:
                         st.write("No summary available.")
 
                 st.divider()
-
-search_mode = st.sidebar.selectbox(
-    "Search Mode",
-    ["Academic (OpenAlex)", "General Knowledge (Wikipedia)"]
-)

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -401,23 +401,50 @@ search_mode = st.sidebar.selectbox(
 st.session_state.last_search_mode = search_mode
 
 search_query = st.sidebar.text_input(
-    "Search query",
+    "Keywords or phrase",
     key="search_query",
     value=st.session_state.get("search_query", ""),
+    help=(
+        "Use this for focused terms or exact phrases.\n\n"
+        "Best when you already know target concepts.\n\n"
+        "Examples:\n"
+        "- photosynthesis in plants\n"
+        "- CRISPR ethics\n"
+        "- transformer attention\n\n"
+        "Required with Broad topic: fill at least one of the two.\n"
+        "Fallback: if Broad topic is empty, search uses this value."
+    ),
 )
 
 search_topic = st.sidebar.text_input(
-    "Research topic",
+    "Broad topic",
     key="search_topic",
     value=st.session_state.get("search_topic", ""),
+    help=(
+        "Use this for broader subject context when exploring.\n\n"
+        "Examples:\n"
+        "- cell biology\n"
+        "- climate change adaptation\n"
+        "- large language models\n\n"
+        "Required with Keywords: fill at least one of the two.\n"
+        "Fallback: if Keywords is empty, this becomes both the raw search query "
+        "and reranking topic."
+    ),
 )
 
 search_research_question = st.sidebar.text_area(
-    "Research question",
+    "Specific question to answer",
     key="search_research_question",
     value=st.session_state.get("search_research_question", ""),
     height=90,
-    help="What exactly are you trying to learn, compare, explain, or solve?",
+    help=(
+        "Optional but strongly recommended.\n\n"
+        "Use this for the exact question you want answered, compared, or explained.\n"
+        "It improves reranking toward answer usefulness.\n\n"
+        "Examples:\n"
+        "- How does amoeba energy metabolism differ from tree photosynthesis?\n"
+        "- Which methods improve retrieval quality in small RAG datasets?"
+    ),
 )
 
 search_level = st.sidebar.selectbox(


### PR DESCRIPTION
1) clicking advanced controls now enable the changing of lexical prefilter keep -> audience-level weights to not be greyed out and I checked and they definitely do something, the rankings change when maxing semantic weight vs audience-level weight
2) I fixed the llm reranker not being able to parse some str so it falls back on not using it. e.g. 
"LLM reranker unavailable (could not convert string to float: "0.2\n\nThe source is topically relevant, as it discusses photosynthesis, but it doesn't directly address the research question about the differences in photosynthesis between amoeba and trees. The tone and language are also quite technical, which may be challenging for an undergraduate student. Overall, the source seems to be more relevant to advanced researchers in the field of artificial photosynthesis rather than the user's specific question."); continuing without it."
 
won't show up anymore
3) when you check a candidate source for the first time it minimizes the list. I changed it so that it is always expanded which is the trade off for looking more polished in a demo I think. We can manually minimize it after 
4) I asked for any obvious bugs and got 
__LLM reranker score parsing can over-score fraction-style outputs__\
The new parser correctly handles `"0.2\n\nexplanation"`, but if a model returns `"7/10"`, current behavior becomes `1.0` (clamped), which is likely too high.

- Better behavior: detect `a/b` fractions and convert to `a/b` (so `7/10 -> 0.7`) before fallback numeric extraction.

so I had gpt fix that.
5) I had it update the field names to keywords or phrase,  broad topic, and specific question to answer under search mode. the first two were confusing to me. it also tells you when to use what 
<img width="696" height="235" alt="c" src="https://github.com/user-attachments/assets/0e40227f-eaeb-4dbc-859f-96a0eae1897e" />
<img width="716" height="315" alt="b" src="https://github.com/user-attachments/assets/f8521e1e-4765-4316-924a-001c9f0f41bb" />
<img width="720" height="316" alt="a" src="https://github.com/user-attachments/assets/b71b3f03-09e9-4097-b214-5eb40421fe38" />
